### PR TITLE
Better definition of what AUT is.

### DIFF
--- a/current/README.md
+++ b/current/README.md
@@ -1,6 +1,6 @@
 # The Archives Unleashed Toolkit: Latest Documentation
 
-The Archives Unleashed Toolkit is an open-source platform for analyzing web archives built on [Hadoop](https://hadoop.apache.org/). Tight integration with Hadoop provides powerful tools for analytics and data processing via [Spark](http://spark.apache.org/).
+The Archives Unleashed Toolkit is an open-source platform for analyzing web archives built on [Apache Spark](http://spark.apache.org/), which provides powerful tools for analytics and data processing.
 
 Most of this documentation is built on [resilient distributed datasets (RDD)](https://spark.apache.org/docs/latest/rdd-programming-guide.html). We are working on adding support for [DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html#datasets-and-dataframes). You can read more about this in our experimental [DataFrames section](#dataframes), and at our [[Using the Archives Unleashed Toolkit with PySpark]] tutorial.
 


### PR DESCRIPTION
I believe this better reflects the current status of the project. I'd argue the Hadoop part was earlier versions of Warcbase, and now things are pretty much all Apache Spark, with Hadoop hidden under the covers.

Anyway, good for discussion :smile: 

...and if we're good with changing it, I can take care of changing it on the aut repo, and the website.