### PR TITLE
Change extractValidPagesDF -> webpages, partially resolves #23

### DIFF
--- a/current/collection-analysis.md
+++ b/current/collection-analysis.md
@@ -32,7 +32,7 @@ What do I do with the results? See [this guide](rdd-results.md)!
 import io.archivesunleashed._
 import io.archivesunleashed.df._
 
-RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
+RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).webpages()
   .select($"Url")
   .show(20, false)
 ```
@@ -75,7 +75,7 @@ What do I do with the results? See [this guide](rdd-results.md)!
 import io.archivesunleashed._
 import io.archivesunleashed.df._
 
-RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
+RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).webpages()
   .select(ExtractDomainDF($"Url").as("Domain"))
   .groupBy("Domain").count().orderBy(desc("count"))
   .show(20, false)

--- a/current/df-results.md
+++ b/current/df-results.md
@@ -13,7 +13,7 @@ If you want to return a set of results, the counterpart of `.take(10)` with RDDs
 So, something like (in Scala):
 
 ```scala
-RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).extractValidPagesDF()
+RecordLoader.loadArchives("src/test/resources/warc/example.warc.gz", sc).webpages()
   // more transformations here...
   .head(10)
 ```

--- a/current/index.md
+++ b/current/index.md
@@ -19,7 +19,7 @@ import io.archivesunleashed._
 import io.archivesunleashed.df._
 
 val df = RecordLoader.loadArchives("example.arc.gz", sc)
-  .extractValidPagesDF()
+  .webpages()
 
 df.printSchema()
 ```
@@ -31,7 +31,7 @@ import io.archivesunleashed._
 import io.archivesunleashed.df._
 
 val df = RecordLoader.loadArchives("example.arc.gz", sc)
-  .extractValidPagesDF()
+  .webpages()
 
 df.select(ExtractBaseDomain($"Url").as("Domain"))
   .groupBy("Domain").count().orderBy(desc("count")).show()

--- a/current/link-analysis.md
+++ b/current/link-analysis.md
@@ -330,7 +330,7 @@ val result = udf((vs: Seq[Any]) => vs(0)
 
 val df = RecordLoader
           .loadArchives("Sample-Data/*gz", sc)
-          .extractValidPagesDF()
+          .webpages()
           .select(RemovePrefixWWWDF(ExtractDomainDF($"url"))
             .as("Domain"), $"url"
             .as("url"),$"crawl_date", explode_outer(ExtractLinksDF($"url", $"content"))

--- a/current/text-analysis.md
+++ b/current/text-analysis.md
@@ -66,7 +66,7 @@ import io.archivesunleashed._
 import io.archivesunleashed.df._
 
 RecordLoader.loadArchives("example.warc.gz", sc)
-  .extractValidPagesDF()
+  .webpages()
   .select(RemoveHTMLDF($"content"))
   .write
   .option("header","true")


### PR DESCRIPTION
In AUT [#379](https://github.com/archivesunleashed/aut/pull/379), `extractValidPagesDF` was changed to `webpages` for data frames. I was testing some of the documentation and found some of these old calls. This PR fixes those scripts.