### PR TITLE
Add documentation for Python filter examples.

### DIFF
--- a/current/collection-analysis.md
+++ b/current/collection-analysis.md
@@ -146,7 +146,18 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ### Python DF
 
-TODO
+```python
+from aut import *
+from pyspark.sql.functions import col
+
+url_pattern = "http://[^/]+/[^/]+/"
+
+WebArchive(sc, sqlContext, "/path/to/warcs")\
+  .webpages()\
+  .select("url")\
+  .filter(col("url").rlike(url_pattern))\
+  .show(10, False)
+```
 
 ## Extract HTTP Status Codes
 

--- a/current/image-analysis.md
+++ b/current/image-analysis.md
@@ -292,7 +292,7 @@ extractPopularImages(df,10,30,30).show()
 
 ### Python DF
 
-TODO
+[TODO](https://github.com/archivesunleashed/aut/issues/409)
 
 ## Find Images Shared Between Domains
 

--- a/current/standard-derivatives.md
+++ b/current/standard-derivatives.md
@@ -107,7 +107,7 @@ sys.exit
 
 ### Python DF
 
-TODO
+[TODO](https://github.com/archivesunleashed/aut/issues/409)
 
 ## Extract Binary Info
 

--- a/current/text-analysis.md
+++ b/current/text-analysis.md
@@ -142,10 +142,14 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ```python
 from aut import *
+from pyspark.sql.functions import col
+
+domains = ["www.archive.org"]
 
 WebArchive(sc, sqlContext, "/path/to/warcs")\
   .webpages()\
   .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_html(Udf.remove_http_header("content")).alias("content"))\
+  .filter(col("domain").isin(domains))\
   .write.csv("plain-text-domain-df/")
 ```
 
@@ -188,7 +192,18 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ### Python DF
 
-TODO
+```python
+from aut import *
+from pyspark.sql.functions import col
+
+url_pattern = "%http://www.archive.org/details/%"
+
+WebArchive(sc, sqlContext, "/path/to/warcs")\
+  .webpages()\
+  .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_html(Udf.remove_http_header("content")).alias("content"))\
+  .filter(col("url").like(url_pattern))\
+  .write.csv("details-df/")
+```
 
 ## Extract Plain Text Minus Boilerplate
 
@@ -306,6 +321,7 @@ import io.archivesunleashed._
 import io.archivesunleashed.udfs._
 
 val dates = Array("2008", "2015")
+
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
   .select($"crawl_date", extractDomain($"url").as("domain"), $"url", removeHTML(removeHTTPHeader($"content")).as("content"))
@@ -315,7 +331,18 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ### Python DF
 
-TODO
+```python
+from aut import *
+from pyspark.sql.functions import col
+
+dates = "2009[10][09]\d\d"
+
+WebArchive(sc, sqlContext, "/path/to/warcs")\
+  .webpages()\
+  .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_html(Udf.remove_http_header("content")).alias("content"))\
+  .filter(col("crawl_date").rlike(dates))\
+  .write.csv("plain-text-date-filtered-2008-2015-df/")
+```
 
 ## Extract Plain Text Filtered by Language
 
@@ -371,7 +398,20 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ### Python DF
 
-TODO
+```python
+from aut import *
+from pyspark.sql.functions import col
+
+domains = ["www.geocities.com"]
+languages = ["fr"]
+
+WebArchive(sc, sqlContext, "/path/to/warcs")\
+  .webpages()\
+  .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_html(Udf.remove_http_header("content")).alias("content"))\
+  .filter(col("domain").isin(domains))\
+  .filter(col("language").isin(languages))\
+  .write.csv("plain-text-fr-df/")
+```
 
 ## Extract Plain text Filtered by Keyword
 
@@ -415,7 +455,18 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
 
 ### Python DF
 
-TODO
+```python
+from aut import *
+from pyspark.sql.functions import col
+
+content = "%radio%"
+
+WebArchive(sc, sqlContext, "/path/to/warcs")\
+  .webpages()\
+  .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_html(Udf.remove_http_header("content")).alias("content"))\
+  .filter(col("content").like(content))
+  .write.csv("plain-text-radio-df/")
+```
 
 ## Extract Raw HTML
 


### PR DESCRIPTION
- Resolve all TODO for Python that required a `.filter()`
- Linked some TODO open issues
- Resolves https://github.com/archivesunleashed/aut/issues/410

Here is a notebook that can be used as an example run through: https://github.com/archivesunleashed/notebooks/blob/master/aut-pyspark-documentation-examples.ipynb

```
 export PYSPARK_DRIVER_PYTHON=jupyter; export PYSPARK_DRIVER_PYTHON_OPTS=notebook; ~/bin/spark-2.4.5-bin-hadoop2.7/bin/pyspark --py-files ~/Projects/au/aut/target/aut.zip --jars ~/Projects/au/aut/target/aut-0.70.1-SNAPSHOT-fatjar.jar
```