### PR TITLE
Removes Extract Entities from Documentation

### DIFF
--- a/current/README.md
+++ b/current/README.md
@@ -50,7 +50,6 @@ and working with the results.
   - [Extract Plain Text Filtered by Language](text-analysis.md#Extract-Plain-Text-Filtered-by-Language)
   - [Extract Plain Text Filtered by Keyword](text-analysis.md#Extract-Plain-Text-Filtered-by-Keyword)
   - [Extract Raw HTML](text-analysis.md#Extract-Raw-HTML)
-  - [Extract Named Entities](text-analysis.md#Extract-Named-Entities)
 - **[Link Analysis](https://github.com/archivesunleashed/aut-docs-new/blob/master/current/link-analysis.md)**
   : How do I...
   - [Extract Simple Site Link Structure](link-analysis.md#Extract-Simple-Site-Link-Structure)

--- a/current/text-analysis.md
+++ b/current/text-analysis.md
@@ -11,7 +11,6 @@
 - [Extract Plain Text Filtered by Language](#Extract-Plain-Text-Filtered-by-Language)
 - [Extract Plain Text Filtered by Keyword](#Extract-Plain-Text-Filtered-by-Keyword)
 - [Extract Raw HTML](#Extract-Raw-HTML)
-- [Extract Named Entities](#Extract-Named-Entities)
 
 For all the scripts below, you can type `:paste` into Spark Shell, paste the
 script, and then run it with <kbd>CTRL</kbd>+<kbd>d</kbd>:
@@ -511,58 +510,3 @@ WebArchive(sc, sqlContext, "/path/to/warcs")\
   .select("crawl_date", Udf.extract_domain("url").alias("domain"), "url", Udf.remove_http_header("content").alias("content"))\
   .write.csv("plain-html-df/")
 ```
-
-## Extract Named Entities
-
-### Scala RDD
-
-**NER is Extremely Resource Intensive and Time Consuming!**
-
-Named Entity Recognition is extremely resource intensive, and will take a very
-long time. Our recommendation is to begin testing NER on one or two WARC files,
-before trying it on a larger body of information. Depending on the speed of
-your system, it can take a day or two to process information that you are used
-to working with in under an hour.
-
-The following script uses the [Stanford Named Entity
-Recognizer](http://nlp.stanford.edu/software/CRF-NER.shtml) to extract names of
-entities – persons, organizations, and locations – from collections of ARC/WARC
-files or extracted texts. You can find a version of Stanford NER in our
-aut-resources repo located
-[here](https://github.com/archivesunleashed/aut-resources).
-
-The script requires a NER classifier model. There is one provided in the
-Stanford NER package (in the `classifiers` folder) called
-`english.all.3class.distsim.crf.ser.gz`, but you can also use your own.
-
-```scala
-import io.archivesunleashed._
-import io.archivesunleashed.app._
-import io.archivesunleashed.matchbox._
-
-sc.addFile("/path/to/classifier")
-
-ExtractEntities.extractFromRecords("/path/to/classifier/english.all.3class.distsim.crf.ser.gz", "/path/to/warcs", "output-ner/", sc)
-```
-
-Note the call to `addFile()`. This is necessary if you are running this script
-on a cluster; it puts a copy of the classifier on each worker node. The
-classifier and input file paths may be local or on the cluster (e.g.,
-`hdfs:///user/joe/collection/`).
-
-The output of this script will be in the [WANE
-format](https://webarchive.jira.com/wiki/spaces/ARS/pages/88309872/WANE+Overview+and+Technical+Details),
-consisting of a JSON per line:
-
-```json
-{"timestamp":"20091218","url":"http://www.equalvoice.ca/images/images/french/js/images/sponsors/enbridge.jpg","named_entities":{"PERSON":["Sheila James Fund","Coyle","Sheila James","Regan"],"ORGANIZATION":["Equal Voice Equal Voice HOME","Mission Advisory Board Board of Directors & Staff Programs and Events EV Programs EV Events EV Speaks Out Research","NCR Ottawa British Columbia Alberta North Alberta South Youth Founders","Equal Voice","Equal Voice"],"LOCATION":["Toronto","Toronto Municipal Nova Scotia Newfoundland","Canada"]},"digest":"sha1:5U34IRCL74PEWGYHRGCXBCB3D2TDWHFE"}
-{"timestamp":"20091218","url":"http://www.liberal.ca/share_e.aspx?link=http://www.liberal.ca/en/newsroom/liberal-tv/category/56E6B9156BA42F5F_events/4.36363636364/ZSj39F5L1rM~hommage-a-ceux-qui-ont-servi","named_entities":{"PERSON":["Edward Isand","Ignatieff","Harper","Flaherty","Stephen Harper","Ignatieff","Michael"],"ORGANIZATION":["Liberal Party of Canada","Liberal Party of Canada Home","Community Party Central History Board of directors Election Readiness Commissions En Famille","Quebec Saskatchewan Contact us Newsroom Blog Media Releases Official Graphics Media Contact Information RSS Newsfeeds Liberal TV","Party","Liberal Party of Canada","Liberal Party","Yarmouth","Federal Liberal Agency of Canada","Liberal Party of Canada"],"LOCATION":["Alberta British Columbia Manitoba New Brunswick Newfoundland","Labrador Nova Scotia Ontario","Copenhagen","Canada","Canada"]},"digest":"sha1:LQ45W44PR6MG6MZEGEVMZVQC3YHIWDRC"}
-```
-
-### Scala DF
-
-**To be implemented.**
-
-### Python DF
-
-**To be implemented.**

--- a/current/toolkit-walkthrough.md
+++ b/current/toolkit-walkthrough.md
@@ -17,7 +17,6 @@ If you have any questions, let us know in [Slack](http://slack.archivesunleashed
 - [Extracting some Text](#extracting-some-text)
   - [Ouch: Our First Error](#ouch-our-first-error)
   - [Other Text Analysis Filters](#other-text-analysis-filters)
-- [People, Places, and Things: Entities Ahoy!](#people-places-and-things-entities-ahoy)
 - [Web of Links: Network Analysis](#web-of-links-network-analysis)
 - [Working with the Data](#working-with-the-data)
 - [Acknowledgements and Final Notes](#acknowledgements-and-final-notes)
@@ -318,40 +317,6 @@ RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
 
 You could now try uploading one of the plain text files using a website like
 [Voyant Tools](https://voyant-tools.org).
-
-## People, Places, and Things: Entities Ahoy
-
-One last thing we can do with text is to try to use [Named-entity
-recognition](https://en.wikipedia.org/wiki/Named-entity_recognition) (NER) to
-try to find people, organizations, and locations within the text.
-
-To do this, we need to have a classifier - luckily, we have included an
-English-language one from the [Stanford NER
-project](https://nlp.stanford.edu/software/CRF-NER.shtml) in this Docker image!
-
-The code is below. It looks a bit different than what you are used to:
-
-```scala
-import io.archivesunleashed._
-import io.archivesunleashed.app._
-import io.archivesunleashed.matchbox._
-
-ExtractEntities.extractFromRecords("/aut-resources/NER/english.all.3class.distsim.crf.ser.gz", "/aut-resources/Sample-Data/*.gz", "/data/ner-output/", sc)
-```
-
-This will take a fair amount of time, even on a small amount of data. It is
-very computationally intensive! I often use it as an excuse to go make a cup of
-coffee.
-
-When it is done, you will have results in the `/data` directory. The first line
-should look like:
-
-```scala
-{"timestamp":"20060622","url":"http://www.gca.ca/indexcms/?organizations&orgid=27","named_entities":{"persons":["Marie"],"organizations":["Green Communities Canada","Green Communities Canada News and Events Our Programs Join Green Communities Canada Downloads Privacy Policy Site Map GCA Clean North Kathie Brosemer"],"locations":["St. E. Sault","Canada"]},"digest":"sha1:3e3dc1e855b994d838564ac8d921451451a199d5"}
-```
-
-Here we can see that in this website, it was probably taking about Sault Ste.
-Marie, Ontario.
 
 ## Web of Links: Network Analysis
 


### PR DESCRIPTION
As per [AUT #469](https://github.com/archivesunleashed/aut/issues/469), this pull request removes reference to Extract Entities from:

- the table of contents;
- text analysis section (both the internal table of contents + the content itself);
- the Toolkit walkthrough

I'm pretty sure I've caught them all but in case I have missed something let me know!