### PR TITLE
Update documentation to resolve #88.

### DIFF
--- a/docs/auk-derivatives.md
+++ b/docs/auk-derivatives.md
@@ -45,7 +45,7 @@ webpages.groupBy(removePrefixWWW(extractDomain($"Url")).alias("url"))
   .write.csv("/path/to/derivatives/auk/all-domains/output")
 
 // Full-text.
-webpages.select($"crawl_date", removePrefixWWW(extractDomain(($"url")).alias("domain")), $"url", removeHTML(removeHTTPHeader(($"content"))))
+webpages.select($"crawl_date", removePrefixWWW(extractDomain(($"url")).alias("domain")), $"url", $"content")
   .write.csv("/path/to/derivatives/auk/full-text/output")
 
 // GraphML
@@ -83,7 +83,7 @@ webpages.groupBy(remove_prefix_www(extract_domain("url")).alias("url")) \
   .write.csv("/path/to/derivatives/auk/all-domains/output")
 
 # Full-text.
-webpages.select("crawl_date", remove_prefix_www(extract_domain("url")).alias("domain"), "url", remove_html(remove_http_header("content")).alias("content"))\
+webpages.select("crawl_date", remove_prefix_www(extract_domain("url")).alias("domain"), "url", "content")\
   .write.csv("/path/to/derivatives/auk/full-text/output")
 
 # Create DataFrame for GraphML output

--- a/docs/dataframe-schemas.md
+++ b/docs/dataframe-schemas.md
@@ -31,7 +31,7 @@ language); and `.webgraph()` which includes hyperlink information.
 - `mime_type_web_server` (string)
 - `mime_type_tika` (string)
 - `language` (string)
-- `content` (string)
+- `content` (string) [Note: HTTP Headers, and HTML is removed.]
 
 ## Web Graph
 

--- a/docs/text-analysis.md
+++ b/docs/text-analysis.md
@@ -32,7 +32,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", removeHTML($"content"))
+  .select($"crawl_date", extractDomain($"url"), $"url", $"content")
   .write.csv("plain-text-df/")
 ```
 
@@ -43,7 +43,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html("content").alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .write.csv("plain-text-df/")
 ```
 
@@ -75,7 +75,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select(removeHTML(removeHTTPHeader($"content")))
+  .select($"content")
   .write.csv("plain-text-noheaders-df/")
 ```
 
@@ -86,7 +86,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select(remove_html(remove_http_header("content")).alias("content")) \
+  .select("content")) \
   .write.csv("plain-text-noheaders-df/")
 ```
 
@@ -120,7 +120,7 @@ val domains = Array("www.archive.org", "geocities.org")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("plain-text-domain-df/")
 ```
@@ -135,7 +135,7 @@ domains = ["www.archive.org"]
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("domain").isin(domains)) \
   .write.csv("plain-text-domain-df/")
 ```
@@ -172,7 +172,7 @@ val urlPattern = Array("(?i)http://www.archive.org/details/.*")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasUrlPatterns($"url", lit(urlPattern)))
   .write.csv("details-df/")
 ```
@@ -187,7 +187,7 @@ url_pattern = "%http://www.archive.org/details/%"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("url").like(url_pattern)) \
   .write.csv("details-df/")
 ```
@@ -223,7 +223,7 @@ val domains = Array("www.archive.org")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", extractBoilerpipeText(removeHTTPHeader($"content")))
+  .select($"crawl_date", extractDomain($"url"), $"url", extractBoilerpipeText($"content"))
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("plain-text-no-boilerplate-df/")
 ```
@@ -235,7 +235,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", extract_boilerplate(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", extract_boilerplate("content").alias("content")) \
   .write.csv("plain-text-no-boilerplate-df/")
 ```
 
@@ -311,7 +311,7 @@ val dates = Array("2008", "2015")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").as("domain"), $"url", removeHTML(removeHTTPHeader($"content")).as("content"))
+  .select($"crawl_date", extractDomain($"url").as("domain"), $"url", $"content")
   .filter(hasDate($"crawl_date", lit(dates)))
   .write.csv("plain-text-date-filtered-2008-2015-df/")
 ```
@@ -326,7 +326,7 @@ dates = "2009[10][09]\d\d"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("crawl_date").rlike(dates)) \
   .write.csv("plain-text-date-filtered-2008-2015-df/")
 ```
@@ -362,7 +362,7 @@ val languages = Array("fr")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
   .write.csv("plain-text-fr-df/")
@@ -379,7 +379,7 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
   .filter(hasDomains(extractDomain($"url"), lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", $"content")
   .write.csv("plain-text-fr-df/")
 ```
 
@@ -394,7 +394,7 @@ languages = ["fr"]
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("domain").isin(domains)) \
   .filter(col("language").isin(languages)) \
   .write.csv("plain-text-fr-df/")
@@ -435,7 +435,7 @@ val content = Array("radio")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasContent($"content", lit(content)))
   .write.csv("plain-text-radio-df/")
 ```
@@ -450,7 +450,7 @@ content = "%radio%"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content")) \
   .filter(col("content").like(content)) \
   .write.csv("plain-text-radio-df/")
 ```
@@ -484,7 +484,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("example.warc.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", removeHTTPHeader($"content"))
+  .select($"crawl_date", extractDomain($"url"), $"url", $"content")
   .write.csv("plain-html-df/")
 ```
 
@@ -495,6 +495,6 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_http_header("content").alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .write.csv("plain-html-df/")
 ```

--- a/docs/toolkit-walkthrough.md
+++ b/docs/toolkit-walkthrough.md
@@ -204,7 +204,7 @@ val domains = Set("www.liberal.ca")
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("/data/liberal-party-text")
 ```
@@ -236,7 +236,7 @@ val domains = Set("www.liberal.ca")
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("/data/liberal-party-text")
 ```
@@ -286,7 +286,7 @@ RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
   .filter(hasDomains(extractDomain($"url"), lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/liberal-party-french-text")
 ```
 
@@ -301,7 +301,7 @@ val dates = Array("2006")
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
   .filter(hasDate($"crawl_date", lit(dates)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/2006-text")
 ```
 
@@ -314,7 +314,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTTPHeader(removeHTML($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/text-no-headers")
 ```
 

--- a/website/versioned_docs/version-0.80.0/auk-derivatives.md
+++ b/website/versioned_docs/version-0.80.0/auk-derivatives.md
@@ -46,7 +46,7 @@ webpages.groupBy(removePrefixWWW(extractDomain($"Url")).alias("url"))
   .write.csv("/path/to/derivatives/auk/all-domains/output")
 
 // Full-text.
-webpages.select($"crawl_date", removePrefixWWW(extractDomain(($"url")).alias("domain")), $"url", removeHTML(removeHTTPHeader(($"content"))))
+webpages.select($"crawl_date", removePrefixWWW(extractDomain(($"url")).alias("domain")), $"url", $"content")
   .write.csv("/path/to/derivatives/auk/full-text/output")
 
 // GraphML

--- a/website/versioned_docs/version-0.80.0/dataframe-schemas.md
+++ b/website/versioned_docs/version-0.80.0/dataframe-schemas.md
@@ -32,7 +32,7 @@ language); and `.webgraph()` which includes hyperlink information.
 - `mime_type_web_server` (string)
 - `mime_type_tika` (string)
 - `language` (string)
-- `content` (string)
+- `content` (string) [Note: HTTP Headers, and HTML is removed.]
 
 ## Web Graph
 

--- a/website/versioned_docs/version-0.80.0/text-analysis.md
+++ b/website/versioned_docs/version-0.80.0/text-analysis.md
@@ -33,7 +33,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", removeHTML($"content"))
+  .select($"crawl_date", extractDomain($"url"), $"url", $"content")
   .write.csv("plain-text-df/")
 ```
 
@@ -44,7 +44,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html("content").alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .write.csv("plain-text-df/")
 ```
 
@@ -76,7 +76,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select(removeHTML(removeHTTPHeader($"content")))
+  .select($"content")
   .write.csv("plain-text-noheaders-df/")
 ```
 
@@ -87,7 +87,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select(remove_html(remove_http_header("content")).alias("content")) \
+  .select("content")) \
   .write.csv("plain-text-noheaders-df/")
 ```
 
@@ -121,7 +121,7 @@ val domains = Array("www.archive.org", "geocities.org")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("plain-text-domain-df/")
 ```
@@ -136,7 +136,7 @@ domains = ["www.archive.org"]
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("domain").isin(domains)) \
   .write.csv("plain-text-domain-df/")
 ```
@@ -173,7 +173,7 @@ val urlPattern = Array("(?i)http://www.archive.org/details/.*")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasUrlPatterns($"url", lit(urlPattern)))
   .write.csv("details-df/")
 ```
@@ -188,7 +188,7 @@ url_pattern = "%http://www.archive.org/details/%"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("url").like(url_pattern)) \
   .write.csv("details-df/")
 ```
@@ -224,7 +224,7 @@ val domains = Array("www.archive.org")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", extractBoilerpipeText(removeHTTPHeader($"content")))
+  .select($"crawl_date", extractDomain($"url"), $"url", extractBoilerpipeText($"content"))
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("plain-text-no-boilerplate-df/")
 ```
@@ -236,7 +236,7 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", extract_boilerplate(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", extract_boilerplate("content").alias("content")) \
   .write.csv("plain-text-no-boilerplate-df/")
 ```
 
@@ -312,7 +312,7 @@ val dates = Array("2008", "2015")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").as("domain"), $"url", removeHTML(removeHTTPHeader($"content")).as("content"))
+  .select($"crawl_date", extractDomain($"url").as("domain"), $"url", $"content")
   .filter(hasDate($"crawl_date", lit(dates)))
   .write.csv("plain-text-date-filtered-2008-2015-df/")
 ```
@@ -327,7 +327,7 @@ dates = "2009[10][09]\d\d"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("crawl_date").rlike(dates)) \
   .write.csv("plain-text-date-filtered-2008-2015-df/")
 ```
@@ -363,7 +363,7 @@ val languages = Array("fr")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
   .write.csv("plain-text-fr-df/")
@@ -380,7 +380,7 @@ RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
   .filter(hasDomains(extractDomain($"url"), lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"language", $"content")
   .write.csv("plain-text-fr-df/")
 ```
 
@@ -395,7 +395,7 @@ languages = ["fr"]
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .filter(col("domain").isin(domains)) \
   .filter(col("language").isin(languages)) \
   .write.csv("plain-text-fr-df/")
@@ -436,7 +436,7 @@ val content = Array("radio")
 
 RecordLoader.loadArchives("/path/to/warcs", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML(removeHTTPHeader($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasContent($"content", lit(content)))
   .write.csv("plain-text-radio-df/")
 ```
@@ -451,7 +451,7 @@ content = "%radio%"
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_html(remove_http_header("content")).alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content")) \
   .filter(col("content").like(content)) \
   .write.csv("plain-text-radio-df/")
 ```
@@ -485,7 +485,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("example.warc.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url"), $"url", removeHTTPHeader($"content"))
+  .select($"crawl_date", extractDomain($"url"), $"url", $"content")
   .write.csv("plain-html-df/")
 ```
 
@@ -496,6 +496,6 @@ from aut import *
 
 WebArchive(sc, sqlContext, "/path/to/warcs") \
   .webpages() \
-  .select("crawl_date", extract_domain("url").alias("domain"), "url", remove_http_header("content").alias("content")) \
+  .select("crawl_date", extract_domain("url").alias("domain"), "url", "content") \
   .write.csv("plain-html-df/")
 ```

--- a/website/versioned_docs/version-0.80.0/toolkit-walkthrough.md
+++ b/website/versioned_docs/version-0.80.0/toolkit-walkthrough.md
@@ -205,7 +205,7 @@ val domains = Set("www.liberal.ca")
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("/data/liberal-party-text")
 ```
@@ -237,7 +237,7 @@ val domains = Set("www.liberal.ca")
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .filter(hasDomains($"domain", lit(domains)))
   .write.csv("/data/liberal-party-text")
 ```
@@ -287,7 +287,7 @@ RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
   .filter(hasDomains(extractDomain($"url"), lit(domains)))
   .filter(hasLanguages($"language", lit(languages)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/liberal-party-french-text")
 ```
 
@@ -302,7 +302,7 @@ val dates = Array("2006")
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
   .filter(hasDate($"crawl_date", lit(dates)))
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTML($"content").alias("content"))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/2006-text")
 ```
 
@@ -315,7 +315,7 @@ import io.archivesunleashed.udfs._
 
 RecordLoader.loadArchives("/aut-resources/Sample-Data/*.gz", sc)
   .webpages()
-  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", removeHTTPHeader(removeHTML($"content").alias("content")))
+  .select($"crawl_date", extractDomain($"url").alias("domain"), $"url", $"content")
   .write.csv("/data/text-no-headers")
 ```
 


### PR DESCRIPTION
- Documentation included duplicate removeHTML and
removeHTTPHeader UDFs on `content`. `webpages()` already removes these
now.