### PR TITLE
Add Citation to Documentation: Issue 92

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -108,9 +108,9 @@ Association for Computing Machinery, New York,
 NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
 
 Your citations help to further the recognition
-of using open-source tools for scientific 
-inquiry, assists in growing the web archiving 
-community, and acknowledges the efforts of 
+of using open-source tools for scientific
+inquiry, assists in growing the web archiving
+community, and acknowledges the efforts of
 contributors to this project.
 
 ## Further Reading

--- a/docs/home.md
+++ b/docs/home.md
@@ -95,11 +95,32 @@ and working with the results.
 
 ### Citing Archives Unleashed
 
-How to cite the Archives Unleashed Toolkit or Cloud in your research:
+This documentation is based on a cookbook approach, providing a series of
+"recipes" for addressing a number of common analytics tasks to provide
+inspiration for your own analysis. We generally provide examples for [resilient
+distributed datasets
+(RDD)](https://spark.apache.org/docs/latest/rdd-programming-guide.html) in
+Scala, and
+[DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html#datasets-and-dataframes)
+in both Scala and Python. We leave it up to you to choose Scala or Python
+flavours of Spark.
 
-> Nick Ruest, Jimmy Lin, Ian Milligan, and Samantha Fritz. 2020. The Archives Unleashed Project: Technology, Process, and Community to Improve Scholarly Access to Web Archives. In _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries in 2020 (JCDL '20)_. Association for Computing Machinery, New York, NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
+How to cite the Archives Unleashed Toolkit or 
+Cloud in your research:
 
-Your citations help to further the recognition of using open-source tools for scientific inquiry, assists in growing the web archiving community, and acknowledges the efforts of contributors to this project.
+> Nick Ruest, Jimmy Lin, Ian Milligan, and 
+Samantha Fritz. 2020. The Archives Unleashed 
+Project: Technology, Process, and Community 
+to Improve Scholarly Access to Web Archives. 
+In _Proceedings of the ACM/IEEE Joint Conference 
+on Digital Libraries in 2020 (JCDL '20)_. 
+Association for Computing Machinery, New York, 
+NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
+
+Your citations help to further the recognition
+of using open-source tools for scientific inquiry, assists in growing the web archiving 
+community, and acknowledges the efforts of 
+contributors to this project.
 
 ## Further Reading
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -93,6 +93,14 @@ and working with the results.
 - **[What to do with DataFrame Results](df-results.md)**
 - **[What to do with RDD Results](rdd-results.md)**
 
+### Citing Archives Unleashed
+
+How to cite the Archives Unleashed Toolkit or Cloud in your research:
+
+> Nick Ruest, Jimmy Lin, Ian Milligan, and Samantha Fritz. 2020. The Archives Unleashed Project: Technology, Process, and Community to Improve Scholarly Access to Web Archives. In _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries in 2020 (JCDL '20)_. Association for Computing Machinery, New York, NY, USA, 157–166. DOI: https://doi.org/10.1145/3383583.3398513
+
+Your citations help to further the recognition of using open-source tools for scientific inquiry, assists in growing the web archiving community, and acknowledges the efforts of contributors to this project.
+
 ## Further Reading
 
 The following two articles provide an overview of the project:

--- a/docs/home.md
+++ b/docs/home.md
@@ -95,20 +95,21 @@ and working with the results.
 
 ### Citing Archives Unleashed
 
-How to cite the Archives Unleashed Toolkit or 
+How to cite the Archives Unleashed Toolkit or
 Cloud in your research:
 
-> Nick Ruest, Jimmy Lin, Ian Milligan, and 
-Samantha Fritz. 2020. The Archives Unleashed 
-Project: Technology, Process, and Community 
-to Improve Scholarly Access to Web Archives. 
-In _Proceedings of the ACM/IEEE Joint Conference 
-on Digital Libraries in 2020 (JCDL '20)_. 
-Association for Computing Machinery, New York, 
+> Nick Ruest, Jimmy Lin, Ian Milligan, and
+Samantha Fritz. 2020. The Archives Unleashed
+Project: Technology, Process, and Community
+to Improve Scholarly Access to Web Archives.
+In _Proceedings of the ACM/IEEE Joint Conference
+on Digital Libraries in 2020 (JCDL '20)_.
+Association for Computing Machinery, New York,
 NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
 
 Your citations help to further the recognition
-of using open-source tools for scientific inquiry, assists in growing the web archiving 
+of using open-source tools for scientific 
+inquiry, assists in growing the web archiving 
 community, and acknowledges the efforts of 
 contributors to this project.
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -95,16 +95,6 @@ and working with the results.
 
 ### Citing Archives Unleashed
 
-This documentation is based on a cookbook approach, providing a series of
-"recipes" for addressing a number of common analytics tasks to provide
-inspiration for your own analysis. We generally provide examples for [resilient
-distributed datasets
-(RDD)](https://spark.apache.org/docs/latest/rdd-programming-guide.html) in
-Scala, and
-[DataFrames](https://spark.apache.org/docs/latest/sql-programming-guide.html#datasets-and-dataframes)
-in both Scala and Python. We leave it up to you to choose Scala or Python
-flavours of Spark.
-
 How to cite the Archives Unleashed Toolkit or 
 Cloud in your research:
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -97,7 +97,7 @@ and working with the results.
 
 How to cite the Archives Unleashed Toolkit or Cloud in your research:
 
-> Nick Ruest, Jimmy Lin, Ian Milligan, and Samantha Fritz. 2020. The Archives Unleashed Project: Technology, Process, and Community to Improve Scholarly Access to Web Archives. In _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries in 2020 (JCDL '20)_. Association for Computing Machinery, New York, NY, USA, 157–166. DOI: https://doi.org/10.1145/3383583.3398513
+> Nick Ruest, Jimmy Lin, Ian Milligan, and Samantha Fritz. 2020. The Archives Unleashed Project: Technology, Process, and Community to Improve Scholarly Access to Web Archives. In _Proceedings of the ACM/IEEE Joint Conference on Digital Libraries in 2020 (JCDL '20)_. Association for Computing Machinery, New York, NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
 
 Your citations help to further the recognition of using open-source tools for scientific inquiry, assists in growing the web archiving community, and acknowledges the efforts of contributors to this project.
 

--- a/website/versioned_docs/version-0.80.0/home.md
+++ b/website/versioned_docs/version-0.80.0/home.md
@@ -94,6 +94,26 @@ and working with the results.
 - **[What to do with DataFrame Results](df-results.md)**
 - **[What to do with RDD Results](rdd-results.md)**
 
+### Citing Archives Unleashed
+
+How to cite the Archives Unleashed Toolkit or
+Cloud in your research:
+
+> Nick Ruest, Jimmy Lin, Ian Milligan, and
+Samantha Fritz. 2020. The Archives Unleashed
+Project: Technology, Process, and Community
+to Improve Scholarly Access to Web Archives.
+In _Proceedings of the ACM/IEEE Joint Conference
+on Digital Libraries in 2020 (JCDL '20)_.
+Association for Computing Machinery, New York,
+NY, USA, 157–166. DOI: [https://doi.org/10.1145/3383583.3398513](https://doi.org/10.1145/3383583.3398513).
+
+Your citations help to further the recognition
+of using open-source tools for scientific
+inquiry, assists in growing the web archiving
+community, and acknowledges the efforts of
+contributors to this project.
+
 ## Further Reading
 
 The following two articles provide an overview of the project:


### PR DESCRIPTION
Forked aut-docs repo to create this PR, which addresses [issue 92](https://github.com/archivesunleashed/aut-docs/issues/92): 
- Creates a new heading on documentation home page (Citing Archives Unleashed)
- Described how cite Archives Unleashed (toolkit/cloud)

This PR implements work outlined in [AUT issue-497](https://github.com/archivesunleashed/aut/issues/497)

@ianmilligan1 @ruebot, happy to help with any changes of this implementation! Thanks for your review.